### PR TITLE
Github enterprise legacy

### DIFF
--- a/src/injections/github.js
+++ b/src/injections/github.js
@@ -6,11 +6,12 @@ export default function injectIconsGithub(target) {
     const $items = $('.js-navigation-item', target);
     $items.each((index, item) => {
       const $item = $(item);
-      const isFile = $item.find('.octicon-file').length > 0;
+      const isFile = $item.find('.octicon-file').length > 0
+      const isSvg = $item.find('.octicon-file-text').length > 0;
       const name = $item.find('.js-navigation-open').text();
       const $icon = $item.find('.icon');
 
-      if (isFile) {
+      if (isFile || isSvg) {
           let className;
           if (isColor) {
             className = fileIcons.getClassWithColor(name) || DEFAULT_ICON;
@@ -18,6 +19,10 @@ export default function injectIconsGithub(target) {
             className = fileIcons.getClass(name) || DEFAULT_ICON;
           }
           $icon.addClass(`gfi ${className}`);
+
+          if (isSvg) {
+            $item.find('svg').remove()
+          }
       }
     });
   });


### PR DESCRIPTION
it seems like the structure of github enterprise is slightly different or my company is on an old version. this change looks for the a slightly different class that is present in github enterprise. closes #2 

<img width="378" alt="screen shot 2018-03-13 at 11 58 46 am" src="https://user-images.githubusercontent.com/1192452/37363752-f10bebb0-26b5-11e8-804a-6950429ac739.png">
